### PR TITLE
Update jansson dependency instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,11 +224,11 @@ First of all, check if your [universal-ctags](https://github.com/universal-ctags
 
 The JSON support for ctags is avaliable if u-ctags is linked to libjansson when compiling.
 
-- macOS
+- macOS, [included by default since February 23 2021](https://github.com/universal-ctags/homebrew-universal-ctags/commit/82db2cf9cb0cdecf62ca9405e767ec025b5ba8ed)
 
   ```bash
   $ brew tap universal-ctags/universal-ctags
-  $ brew install --with-jansson --HEAD universal-ctags/universal-ctags/universal-ctags
+  $ brew install --HEAD universal-ctags/universal-ctags/universal-ctags
   ```
 
 - Ubuntu


### PR DESCRIPTION
The latest tap does not have an optional `--with-jansson` option
anymore, it's installed by default since
[February 23 2021](https://github.com/universal-ctags/homebrew-universal-ctags/commit/82db2cf9cb0cdecf62ca9405e767ec025b5ba8ed)

Calling the install command with the `--with-jansson` option would
return an error from Homebrew.

```
Error: invalid option: --with-jansson
```

In time the whole macOS instructions can probably be removed, but since
the change was made recently, existing installs may need to reinstall
ctags before it works with the JSON feature.